### PR TITLE
Fix typo on use-guard-hook.md

### DIFF
--- a/docs/docs/use-guard-hook.md
+++ b/docs/docs/use-guard-hook.md
@@ -10,7 +10,7 @@ The hook lets you do a permissions check in the frontend.
 ```typescript
 import { useGuard } from "app/guard"
 
-const [[canCreateComment, canDeleteComment], { isLoading }] = useCanCan([
+const [[canCreateComment, canDeleteComment], { isLoading }] = useGuard([
   ["create", "comment"],
   ["delete", "comment" /* args */],
 ])


### PR DESCRIPTION
I saw a possible typo here, I assume that `useCanCan` is what's wrong and the import (`useGuard`) is right.

### What are the changes and their implications?
It's a typo fix, it doesn't touch the code at all.