### PR TITLE
Update types.ts

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -24,6 +24,7 @@ export type PrismaModelsType<T> = keyof Omit<
   | "$transaction"
   | "$on"
   | "$use"
+  | "$reset"                                           
 >
 export interface IRule<IResource, IAbility> {
   reasonText: string


### PR DESCRIPTION
### What are the changes and their implications?

Blitz ads a `$reset` convenience method to Prisma. blitz-guard should strip this out when generating a union type for the models, at least until https://github.com/prisma/prisma/issues/3545 works

### Checklist

- [ ] Tests added for changes
- [ ] Documentation changed (if needed)

